### PR TITLE
Fix bug: Namespace switch prevents LT from returning eval result

### DIFF
--- a/py-src/ltipy.py
+++ b/py-src/ltipy.py
@@ -17,6 +17,7 @@ respond = None
 requests = {}
 connected = noop
 disconnected = noop
+curNs = None
 
 def km_from_string(s=''):
     """create kernel manager from IPKernelApp string
@@ -183,7 +184,10 @@ def initIPy(s):
     disconnected()
 
 def setNs(path):
+  if path==curNs: return
   send("import lttools\nlttools.switch_ns('" + path.replace('\\', '\\\\') + "')")
+  time.sleep(0.1) #wait for msgloop to clear this namespace switch
+  path = curNs
 
 def IPyOutput(l):
   m = re.search('--existing (.*\.json)', l)


### PR DESCRIPTION
If the source file contains errors, namespace switch will fail. Subsequent submission of eval(s) would need to wait for the msgloop to pick up the Exception, otherwise they will be considered to be from the same batch of erroneous submitted source.

This sleep() should not be repeated for each eval, unless the user switch the namespace. As such, I added the check to reduce the latency.
