### PR TITLE
Fixing compatibility with python3

### DIFF
--- a/py-src/ltmain.py
+++ b/py-src/ltmain.py
@@ -47,9 +47,12 @@ def asUnicode(s):
     return str(s)
 
 def ensureUtf(s):
-  if type(s) == unicode:
-    return s.encode('utf8', 'ignore')
-  else:
+  try:
+    if type(s) == unicode:
+      return s.encode('utf8', 'ignore')
+    else:
+      return str(s)
+  except:
     return str(s)
 
 def findLoc(body, line, total):


### PR DESCRIPTION
Added try-except because python3 has no unicode class.