### PR TITLE
future imports fix

### DIFF
--- a/py-src/ltmain.py
+++ b/py-src/ltmain.py
@@ -152,7 +152,11 @@ def stopped():
   return stop
 
 def featureFlags(code):
-  names = code.co_names[1:]
+  futureItems = __future__.__dict__.iteritems()
+  #ensure we only try to get flags for features
+  featureNames = [k for  k,v in futureItems if hasattr(v, 'compiler_flag')]
+  names = [n for n in code.co_names[1:] if n in featureNames]
+
   return [getattr(__future__, name).compiler_flag for name in names]
 
 def addFlags(current, new):


### PR DESCRIPTION
Accumulate and add compiler flags to calls to the compile function for eval/exec code in handleEval when features that alter syntax are imported from the __future__ module. The problem was first reported in issue LightTable/Python/#23. More details are in LightTable/Python/#33. Allows the following code to be executed using Python2 without a syntax error:

```python
from __future__ import print_function
import sys

print('spam', file=sys.stderr)
```

Does not resolve all of the problems with printing to sys.stderr mentioned in LightTable/Python/#23, just the SyntaxError.