### PR TITLE
Python3 unicode -  Fixing issue #24 -NameError: name 'unicode' is not defined

### DIFF
--- a/py-src/ltmain.py
+++ b/py-src/ltmain.py
@@ -46,11 +46,21 @@ def asUnicode(s):
   except:
     return str(s)
 
-def ensureUtf(s):
-  if type(s) == unicode:
-    return s.encode('utf8', 'ignore')
+def ensureUtf(s, encoding='utf8'):
+  """Converts input to unicode if necessary.
+
+  If `s` is bytes, it will be decoded using the `encoding` parameters.
+
+  This function is used for preprocessing /source/ and /filename/ arguments
+  to the builtin function `compile`.
+  """
+  # In Python2, str == bytes.
+  # In Python3, bytes remains unchanged, but str means unicode
+  # while unicode is not defined anymore
+  if type(s) == bytes:
+    return s.decode(encoding, 'ignore')
   else:
-    return str(s)
+    return s
 
 def findLoc(body, line, total):
   for i in range(len(body)):

--- a/py-src/ltmain.py
+++ b/py-src/ltmain.py
@@ -46,7 +46,7 @@ def asUnicode(s):
   except:
     return str(s)
 
-def ensureUtf(s, encoding='utf8'):
+def toUnicode(s, encoding='utf8'):
   """Converts input to unicode if necessary.
 
   If `s` is bytes, it will be decoded using the `encoding` parameters.
@@ -200,11 +200,11 @@ def handleEval(data):
       loc = form[0]
       isEval = False
       try:
-        code= compile(ensureUtf(code), ensureUtf(data[2]["name"]), 'eval')
+        code= compile(toUnicode(code), ensureUtf(data[2]["name"]), 'eval')
         isEval = True
       except:
         try:
-          code= compile(ensureUtf(code), ensureUtf(data[2]["name"]), 'exec')
+          code= compile(toUnicode(code), ensureUtf(data[2]["name"]), 'exec')
         except:
           e = traceback.format_exc()
           send(data[0], "editor.eval.python.exception", {"ex": cleanTrace(e), "meta": loc})
@@ -270,11 +270,11 @@ def ipyEval(data):
       loc = form[0]
       isEval = False
       try:
-        compile(ensureUtf(code), ensureUtf(data[2]["name"]), 'eval')
+        compile(toUnicode(code), ensureUtf(data[2]["name"]), 'eval')
         isEval = True
       except:
         try:
-          compile(ensureUtf(code), ensureUtf(data[2]["name"]), 'exec')
+          compile(toUnicode(code), ensureUtf(data[2]["name"]), 'exec')
         except:
           e = traceback.format_exc()
           send(data[0], "editor.eval.python.exception", {"ex": cleanTrace(e), "meta": loc})

--- a/py-src/ltmain.py
+++ b/py-src/ltmain.py
@@ -200,11 +200,11 @@ def handleEval(data):
       loc = form[0]
       isEval = False
       try:
-        code= compile(toUnicode(code), ensureUtf(data[2]["name"]), 'eval')
+        code= compile(toUnicode(code), toUnicode(data[2]["name"]), 'eval')
         isEval = True
       except:
         try:
-          code= compile(toUnicode(code), ensureUtf(data[2]["name"]), 'exec')
+          code= compile(toUnicode(code), toUnicode(data[2]["name"]), 'exec')
         except:
           e = traceback.format_exc()
           send(data[0], "editor.eval.python.exception", {"ex": cleanTrace(e), "meta": loc})
@@ -270,11 +270,11 @@ def ipyEval(data):
       loc = form[0]
       isEval = False
       try:
-        compile(toUnicode(code), ensureUtf(data[2]["name"]), 'eval')
+        compile(toUnicode(code), toUnicode(data[2]["name"]), 'eval')
         isEval = True
       except:
         try:
-          compile(toUnicode(code), ensureUtf(data[2]["name"]), 'exec')
+          compile(toUnicode(code), toUnicode(data[2]["name"]), 'exec')
         except:
           e = traceback.format_exc()
           send(data[0], "editor.eval.python.exception", {"ex": cleanTrace(e), "meta": loc})


### PR DESCRIPTION
Hi,

I read the few suggestions and fix proposals for bug #24, but here's my own approach, 
feel free to comment.

So the problem is in `ltmain.py::ensureUtf()` which is used when calling 
[compile()](*https://docs.python.org/2/library/functions.html#compile).

> /source/ can either be a Unicode string, a Latin-1 encoded string or
> an AST object.

So if `compile()` expects unicode (let's ignore old-time latin), 
it is `bytes.decode()` that we'd need... and the source encoding might 
depend on the user's platform ? 

Here's my proposal :

``` python
    def ensureUtf(s, encoding='utf8'):
      """Converts input to unicode if necessary.

      If `s` is bytes, it will be decoded using the `encoding` parameters.

      This function is used for preprocessing /source/ and /filename/ arguments
      to the builtin function `compile`.
      """
      # In Python2, str == bytes.
      # In Python3, bytes remains unchanged, but str means unicode
      # while unicode is not defined anymore
      if type(s) == bytes:
        return s.decode(encoding, 'ignore')
      else:
        return s
```

I tested it with python2.7.11 and python3.5.1 on my archlinux platform.

Then, if accepted it makes sense to rename the function to reflect its actual role,
which I did in a later commit.

... edit: Ooops, sorry, the rename was not complete, please check the last commit(s) from my branch.
